### PR TITLE
clickhouse-cpp 1.5.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           token: ${{ github.token }}
           branch: main
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,10 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+      # os: [ubuntu-latest, macos-latest]
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 600
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -26,6 +28,15 @@ jobs:
       - name: Install Homebrew Bundler RubyGems
         if: steps.cache.outputs.cache-hit != 'true'
         run: brew install-bundler-gems
+
+      - name: Adjust Git configuration
+        run: |
+          git lfs uninstall
+          git lfs uninstall --local
+          git lfs uninstall --system
+          git config --global submodule.recurse 1
+          git config --global fetch.parallel 10
+          git config --global submodule.fetchJobs 10
 
       - run: brew test-bot --only-cleanup-before
 

--- a/Formula/clickhouse-cpp.rb
+++ b/Formula/clickhouse-cpp.rb
@@ -1,7 +1,7 @@
 class ClickhouseCpp < Formula
   desc "C++ client library for ClickHouse"
   homepage "https://github.com/ClickHouse/clickhouse-cpp#readme"
-  url "https://github.com/ClickHouse/clickhouse-cpp.git"
+  url "https://github.com/ClickHouse/clickhouse-cpp.git",
     tag:      "1.5.0",
     revision: "1415b5936a2ac2f084850b09057e05fb5798b2f1"
   license "Apache-2.0"

--- a/Formula/clickhouse-cpp.rb
+++ b/Formula/clickhouse-cpp.rb
@@ -1,10 +1,12 @@
 class ClickhouseCpp < Formula
   desc "C++ client library for ClickHouse"
   homepage "https://github.com/ClickHouse/clickhouse-cpp#readme"
-  url "https://github.com/ClickHouse/clickhouse-cpp/archive/refs/tags/1.5.0.tar.gz"
-  sha256 "bb6f268f9c788deb9beccb0b05c2caccf77b141afa408343e09993f12bff55a9"
+  url "https://github.com/ClickHouse/clickhouse-cpp.git"
+    tag:      "1.5.0",
+    revision: "1415b5936a2ac2f084850b09057e05fb5798b2f1"
   license "Apache-2.0"
-  head "https://github.com/ClickHouse/clickhouse-cpp.git", branch: "master"
+  head "https://github.com/ClickHouse/clickhouse-cpp.git",
+    branch: "master"
 
   depends_on "cmake" => [:build, :test]
   depends_on "abseil"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ClickHouse Homebrew tap (by Altinity)
 
-## How do I install these formula?
+## How do I install these formulae?
 
 `brew install altinity/clickhouse/clickhouse`
 


### PR DESCRIPTION
Use GitHub repo by default
Adjust Git configuration
Uninstall Git LFS as a separate step
Keep only macos-latest runner
Set job timeout to 10 hours